### PR TITLE
Disable selection on drag beyond range

### DIFF
--- a/src/components/RangeControlOverlay.js
+++ b/src/components/RangeControlOverlay.js
@@ -65,7 +65,7 @@ class RangeControlOverlay extends Component {
     window.addEventListener('mousemove', this.triggerRangeChange)
     window.addEventListener('mouseup', this.endDrag)
 
-    this.toggleSelection('none');
+    this.toggleSelection('none')
 
     const startValue = evt
       ? this.getValueFromMouseEvent(evt)
@@ -83,7 +83,7 @@ class RangeControlOverlay extends Component {
     window.removeEventListener('mousemove', this.triggerRangeChange)
     window.removeEventListener('mouseup', this.endDrag)
 
-    this.toggleSelection('');
+    this.toggleSelection('')
 
     const endValue = evt
       ? this.getValueFromMouseEvent(evt)
@@ -92,11 +92,11 @@ class RangeControlOverlay extends Component {
   }
 
   toggleSelection (value) {
-    let body = document.getElementsByTagName('body')[0];
-    body.style['user-select'] = value;
-    body.style['-webkit-user-select'] = value;
-    body.style['-moz-user-select'] = value;
-    body.style['-ms-user-select'] = value;
+    let body = document.getElementsByTagName('body')[0]
+    body.style['user-select'] = value
+    body.style['-webkit-user-select'] = value
+    body.style['-moz-user-select'] = value
+    body.style['-ms-user-select'] = value
   }
 
   getValueFromMouseEvent (mouseEvent) {

--- a/src/components/RangeControlOverlay.js
+++ b/src/components/RangeControlOverlay.js
@@ -65,6 +65,8 @@ class RangeControlOverlay extends Component {
     window.addEventListener('mousemove', this.triggerRangeChange)
     window.addEventListener('mouseup', this.endDrag)
 
+    this.toggleSelection('none');
+
     const startValue = evt
       ? this.getValueFromMouseEvent(evt)
       : null
@@ -81,10 +83,20 @@ class RangeControlOverlay extends Component {
     window.removeEventListener('mousemove', this.triggerRangeChange)
     window.removeEventListener('mouseup', this.endDrag)
 
+    this.toggleSelection('');
+
     const endValue = evt
       ? this.getValueFromMouseEvent(evt)
       : null
     this.props.onChangeEnd(endValue)
+  }
+
+  toggleSelection (value) {
+    let body = document.getElementsByTagName('body')[0];
+    body.style['user-select'] = value;
+    body.style['-webkit-user-select'] = value;
+    body.style['-moz-user-select'] = value;
+    body.style['-ms-user-select'] = value;
   }
 
   getValueFromMouseEvent (mouseEvent) {


### PR DESCRIPTION
If you drag beyond the volume or progress slider you highlight parts of the page. This at least wasn't desirable in my particular project.

See callemall/material-ui#2827