### PR TITLE
Round down FormattedTime seconds

### DIFF
--- a/src/components/FormattedTime.js
+++ b/src/components/FormattedTime.js
@@ -32,7 +32,7 @@ class FormattedTime extends Component {
 
     const hours = Math.floor(absNumSeconds / 3600)
     const minutes = Math.floor((absNumSeconds % 3600) / 60)
-    const seconds = Math.round(absNumSeconds) % 60
+    const seconds = Math.floor(absNumSeconds) % 60
 
     return hours > 0
       ? `${prefix}${hours}:${padZero(minutes)}:${padZero(seconds)}`

--- a/tests/FormattedTime-test.js
+++ b/tests/FormattedTime-test.js
@@ -41,12 +41,15 @@ describe('<FormattedTime />', () => {
     expect(time.text()).to.equal('1:00:01')
   })
 
-  it('rounds rendered time to integers', () => {
+  it('rounds down rendered time to integers', () => {
     const time1 = mount(<FormattedTime numSeconds={3601.12874773} />)
     expect(time1.text()).to.equal('1:00:01')
 
-    const time2 = mount(<FormattedTime numSeconds={3601.88999898} />)
-    expect(time2.text()).to.equal('1:00:02')
+    const time2 = mount(<FormattedTime numSeconds={3659.88999898} />)
+    expect(time2.text()).to.equal('1:00:59')
+
+    const time3 = mount(<FormattedTime numSeconds={3601.88999898} />)
+    expect(time3.text()).to.equal('1:00:01')
   })
 
   it('should accept a className', () => {


### PR DESCRIPTION
Right now, a time like 59.8 will result in:

`hours = floor(59.8 / 3600) = 0`
`minutes = floor((59.8 % 3600) / 60) = 0`
`seconds = round(59.8) % 60 = 0`

Thus, `0:00` when it is formatted. This change corrects that to `0:59`. `59.4` has always displayed correctly as `0:59` because the round function results in `59 % 60 = 59`.

The seconds should really still be 59 because the time hasn't turned over to 1 minute yet. I can't really think of a case where it should round up.