### PR TITLE
Accept React 16 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "sinon": "^1.17.6"
   },
   "peerDependencies": {
-    "react": "^15.0.0"
+    "react": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "autobind-decorator": "^1.3.3",


### PR DESCRIPTION
The differences between React 15 and 16 seems to be minimal. I have been using the library for some months in React 16 with no problem.