### PR TITLE
Logo in readme working again.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <img src="https://cdn.rawgit.com/alexanderwallin/react-player-controls/master/docs/img/logo-icon.svg" width="100" height="100" />
+  <img src="https://alexanderwallin.github.io/react-player-controls/assets/logo-icon.svg" width="100" height="100" />
   <br />
   react-player-controls
   <br />


### PR DESCRIPTION
The logo was not working in the readme because it was hosted on rawgit which shut down last year. I changed the link to the logo link from the project demo so it is working again.

```diff
Link before => 
-https://cdn.rawgit.com/alexanderwallin/react-player-controls/master/docs/img/logo-icon.svg
Link now =>
+https://alexanderwallin.github.io/react-player-controls/assets/logo-icon.svg
```